### PR TITLE
最大行号获取逻辑改为:取LineNumberTable中的源码行的最大值，而非最后一行的值

### DIFF
--- a/src/main/java/com/adrninistrator/javacg/handler/MethodHandler4Invoke.java
+++ b/src/main/java/com/adrninistrator/javacg/handler/MethodHandler4Invoke.java
@@ -180,6 +180,14 @@ public class MethodHandler4Invoke extends AbstractMethodHandler {
             maxLineNumber = minLineNumber;
         } else {
             maxLineNumber = lineNumbers[lineNumbers.length - 1].getLineNumber();
+            // 寻找行号中的最大值
+            for (LineNumber lineNumber : lineNumbers) {
+                int sourceLineNumber = lineNumber.getLineNumber();
+                if(maxLineNumber < sourceLineNumber){
+                    maxLineNumber = sourceLineNumber;
+                }
+            }
+
         }
 
         // 记录方法起始代码行号


### PR DESCRIPTION
发现了一个小bug，如果方法以try-resource结尾并且在try-resource中进行return。此时对应code属性中的LineNumberTable的最后一行并不对应源码中的最后一行，可能是try-resource语法糖的原因？

因此我修改了获取最大行号的逻辑：取LineNumberTable中源码行的最大值，而非最后一行的值。虽然解决方式很简单但是还是希望能够采纳我的合并。

**问题源码和字节码中行号的对比**：
![QQ截图20240328104502](https://github.com/Adrninistrator/java-callgraph2/assets/61777204/a726c7d1-bdcb-45e1-ae17-aefbde3d57f3)
![QQ截图20240328104433](https://github.com/Adrninistrator/java-callgraph2/assets/61777204/5cbbd0da-4e19-46e8-a255-5d21e8d2923b)

**问题代码示例（java11编译）**
```java
public static List<String> getPomeLineList() throws IOException {
    List<String> pomLineList = new ArrayList<>();
    try (FileReader fileReader= new FileReader("pom.xml");
         BufferedReader bufferedReader = new BufferedReader(fileReader)){
        String line;
        while((line = bufferedReader.readLine()) != null){
            pomLineList.add(line);
        }
        return pomLineList;
    }
}
```

